### PR TITLE
feat: Initiales Grundgerüst mit TabView

### DIFF
--- a/CryptoTracker/Views/CryptoListView.swift
+++ b/CryptoTracker/Views/CryptoListView.swift
@@ -1,0 +1,23 @@
+//
+//  CryptoListView.swift
+//  CryptoTracker
+//
+//  Created by Michael Winkler on 12.03.25.
+//
+
+import SwiftUI
+
+struct CryptoListView: View {
+    var body: some View {
+        NavigationView {
+            List {
+                Text("Coin Liste kommt hier")
+            }
+            .navigationTitle("Top Coins")
+        }
+    }
+}
+
+#Preview {
+    CryptoListView()
+}

--- a/CryptoTracker/Views/FavoritesView.swift
+++ b/CryptoTracker/Views/FavoritesView.swift
@@ -1,0 +1,19 @@
+//
+//  FavoritesView.swift
+//  CryptoTracker
+//
+//  Created by Michael Winkler on 12.03.25.
+//
+
+import SwiftUI
+
+struct FavoritesView: View {
+    var body: some View {
+        Text("Favoriten")
+            .navigationTitle("Favoriten")
+    }
+}
+
+#Preview {
+    FavoritesView()
+}

--- a/CryptoTracker/Views/MainView.swift
+++ b/CryptoTracker/Views/MainView.swift
@@ -1,0 +1,31 @@
+//
+//  MainView.swift
+//  CryptoTracker
+//
+//  Created by Michael Winkler on 12.03.25.
+//
+
+import SwiftUI
+
+struct MainView: View {
+    var body: some View {
+        TabView {
+            CryptoListView()
+                .tabItem {
+                    Label("Top Coins", systemImage: "bitcoinsign.circle.fill")
+                }
+            FavoritesView()
+                .tabItem {
+                    Label("Favoriten", systemImage: "star.fill")
+                }
+            NewsView()
+                .tabItem {
+                    Label("News", systemImage: "newspaper.fill")
+                }
+        }
+    }
+}
+
+#Preview {
+    MainView()
+}

--- a/CryptoTracker/Views/NewsView.swift
+++ b/CryptoTracker/Views/NewsView.swift
@@ -1,0 +1,19 @@
+//
+//  NewsView.swift
+//  CryptoTracker
+//
+//  Created by Michael Winkler on 12.03.25.
+//
+
+import SwiftUI
+
+struct NewsView: View {
+    var body: some View {
+        Text("News")
+            .navigationTitle("News")
+    }
+}
+
+#Preview {
+    NewsView()
+}


### PR DESCRIPTION
- Erstellt eine TabView mit drei Tabs: "Top Coins", "Favoriten", "News"
- Fügt Platzhalter-Views für alle Tabs hinzu
- Setzt eine einfache NavigationView für die Coin-Liste um